### PR TITLE
Remove unused tray dependency, update other dependencies

### DIFF
--- a/QuietMic/MainWindow.xaml
+++ b/QuietMic/MainWindow.xaml
@@ -4,7 +4,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:QuietMic"
-        xmlns:tb="http://www.hardcodet.net/taskbar"
         mc:Ignorable="d"
         Icon="/Resources/Icons/Icon32x.ico"
         Title="QuietMic" Height="171.333" Width="372">
@@ -20,13 +19,6 @@
             <ColumnDefinition Width="30*"/>
             <ColumnDefinition Width="0*"/>
         </Grid.ColumnDefinitions>
-        <tb:TaskbarIcon x:Name="QuietMicIcon"
-                        Visibility="Visible"
-                        ToolTipText="QuietMic"
-                        IconSource="/Resources/Icons/Icon32x.ico"
-                        MenuActivation="LeftOrRightClick"
-                        PopupActivation="DoubleClick">
-        </tb:TaskbarIcon>
         <Button x:Name="Toggle" Content="Toggle content" HorizontalAlignment="Left" Margin="10,45,0,0" VerticalAlignment="Top" Width="88" Click="Toggle_Click" Height="20" RenderTransformOrigin="0.731,0.45" Grid.Column="1"/>
         <GroupBox Header="Microphone&#xD;&#xA;" HorizontalAlignment="Left" Height="70" Margin="10,10,0,0" VerticalAlignment="Top" Width="226">
             <ComboBox x:Name="MicList" Margin="0,0,0,0" VerticalAlignment="Top" Height="26" SelectionChanged="MicList_Change"  IsReadOnly="True"/>

--- a/QuietMic/QuietMic.csproj
+++ b/QuietMic/QuietMic.csproj
@@ -59,9 +59,6 @@
     <Reference Include="AudioSwitcher.AudioApi.CoreAudio, Version=3.0.0.209, Culture=neutral, PublicKeyToken=fda5729e2db3a64f, processorArchitecture=MSIL">
       <HintPath>..\packages\AudioSwitcher.AudioApi.CoreAudio.3.0.0.1\lib\net40\AudioSwitcher.AudioApi.CoreAudio.dll</HintPath>
     </Reference>
-    <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net451\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
-    </Reference>
     <Reference Include="NonInvasiveKeyboardHookLibrary, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NonInvasiveKeyboardHookLibrary.1.5.0\lib\net452\NonInvasiveKeyboardHookLibrary.dll</HintPath>
     </Reference>

--- a/QuietMic/QuietMic.csproj
+++ b/QuietMic/QuietMic.csproj
@@ -60,7 +60,7 @@
       <HintPath>..\packages\AudioSwitcher.AudioApi.CoreAudio.3.0.0.1\lib\net40\AudioSwitcher.AudioApi.CoreAudio.dll</HintPath>
     </Reference>
     <Reference Include="NonInvasiveKeyboardHookLibrary, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NonInvasiveKeyboardHookLibrary.1.5.0\lib\net452\NonInvasiveKeyboardHookLibrary.dll</HintPath>
+      <HintPath>..\packages\NonInvasiveKeyboardHookLibrary.2.1.0\lib\net452\NonInvasiveKeyboardHookLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/QuietMic/packages.config
+++ b/QuietMic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AudioSwitcher.AudioApi" version="3.0.0" targetFramework="net472" />
-  <package id="AudioSwitcher.AudioApi.CoreAudio" version="3.0.0.1" targetFramework="net472" />
-  <package id="NonInvasiveKeyboardHookLibrary" version="1.5.0" targetFramework="net472" />
+  <package id="AudioSwitcher.AudioApi" version="3.0.0" targetFramework="net48" />
+  <package id="AudioSwitcher.AudioApi.CoreAudio" version="3.0.0.1" targetFramework="net48" />
+  <package id="NonInvasiveKeyboardHookLibrary" version="2.1.0" targetFramework="net48" />
 </packages>

--- a/QuietMic/packages.config
+++ b/QuietMic/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="AudioSwitcher.AudioApi" version="3.0.0" targetFramework="net472" />
   <package id="AudioSwitcher.AudioApi.CoreAudio" version="3.0.0.1" targetFramework="net472" />
-  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net472" />
   <package id="NonInvasiveKeyboardHookLibrary" version="1.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Notes
- If one day I want to implement the tray feature properly I will probably reuse this library, but for now this is an useless dependency, so let's remove it
- NonInvasiveKeyboardHookLibrary is set to 2.1.0 because the 2.1.1 release does not support .NET Framework but only .NET Core